### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/fs1pg/__init__.py
+++ b/custom_components/fs1pg/__init__.py
@@ -22,7 +22,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug("Using device_mac: %s", device_mac)
 
     hass.data.setdefault(DOMAIN, {})
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
 
     return True
 


### PR DESCRIPTION
Change line 25:
"hass.config_entries.async_setup_platforms(entry, _PLATFORMS)" by
"await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)"

References:
https://github.com/vwt12eh8/hassio-ecoflow/issues/76 https://community.home-assistant.io/t/issues-with-nest-protect-after-installing-20230503-1/567537/6