### PR TITLE
Fix for HA 2022.12+

### DIFF
--- a/custom_components/fs1pg/__init__.py
+++ b/custom_components/fs1pg/__init__.py
@@ -22,7 +22,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug("Using device_mac: %s", device_mac)
 
     hass.data.setdefault(DOMAIN, {})
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
The async_setup_platforms method was removed in 2022.12: https://developers.home-assistant.io/blog/2022/07/08/config_entry_forwards/

When I apply this change locally it works flawlessly.